### PR TITLE
Drop duplicate name for map

### DIFF
--- a/test-cases.yaml
+++ b/test-cases.yaml
@@ -109,7 +109,6 @@ test1:
         - name: "TERRAIN"
           opacity: 0.5
       static: False # (<class 'bool'>, FieldInfo(annotation=NoneType, required=False))
-      title: "Trajectories & Patrol Events" # (<class 'str'>, FieldInfo(annotation=NoneType, required=False))
 
     # Parameters for 'Persist Patrols Ecomap as Text' using task `persist_text`.
     traj_pe_ecomap_html_urls: {}


### PR DESCRIPTION
Removes this duplicate name from the map

![image](https://github.com/user-attachments/assets/cb91234b-6104-4b8f-a1c7-9de9d04e7795)
